### PR TITLE
Vcpkg sdl

### DIFF
--- a/Sources/CSDL2/shims.h
+++ b/Sources/CSDL2/shims.h
@@ -9,6 +9,8 @@
     #else
        error "Unknown Apple platform"
     #endif
+#elif __has_include("windows_generated.h")
+    #include "windows_generated.h"
 #else
 	#include "other_platforms.h"
 #endif

--- a/copylibs.ps1
+++ b/copylibs.ps1
@@ -1,4 +1,9 @@
 $bindir = (pkgconf --variable exec_prefix sdl2).Trim()
 $libdir = (pkgconf --variable libdir sdl2).Trim()
-Copy-Item ($bindir + '/SDL2.dll') .build/debug
-Copy-Item ($libdir + '/SDL2.lib') .build/debug
+foreach ($config in "debug", "release") {
+    $path = ".build/$config"
+    if (Test-Path -Path $path) {
+        Copy-Item ($bindir + '/SDL2.dll') $path
+        Copy-Item ($libdir + '/SDL2.lib') $path
+    }
+}

--- a/copylibs.ps1
+++ b/copylibs.ps1
@@ -1,0 +1,4 @@
+$bindir = (pkgconf --variable exec_prefix sdl2).Trim()
+$libdir = (pkgconf --variable libdir sdl2).Trim()
+Copy-Item ($bindir + '/SDL2.dll') .build/debug
+Copy-Item ($libdir + '/SDL2.lib') .build/debug

--- a/genshim.ps1
+++ b/genshim.ps1
@@ -1,0 +1,2 @@
+$includedir = (pkgconf --variable includedir sdl2).Trim()
+Write-Output ('#include "' + $includedir + '/SDL2/SDL.h"') > Sources/CSDL2/windows_generated.h


### PR DESCRIPTION
### Description

This branch contains changes to make SwiftSDL2 build on Windows using the vcpkg build of SDL2.

### Detailed Design

The Windows version of the Swift Package Manager (SPM) is known to be buggy still. What I've discovered is that it doesn't correctly use the output of `pkg-config --cflags sdl2` to allow the header files to be found when building the CSDL2 module. So, to bypass the problem for now, I've written a simple PowerShell script that calls pkgconf (AKA pkg-config), and constructs a simple header file, "windows_generated.h" which will be included by shim.h if it exists.  Currently this script needs to be run manually before `swift test` will run correctly on Windows. Here's how to test this PR:

1. Clone vcpkg into the suggested directory (C:\dev) (see this page https://vcpkg.io/en/getting-started.html), and bootstrap it.
2. Install sdl2 with `vcpkg install --triplet x64-windows sdl2`.
3. Install pkgconf:  `vcpkg install --triplet x64-windows pkgconf`.
4. Add `C:\dev\vcpkg\installed\x64-windows\tools\pkgconf\` to your path. (Modify registry or locally via `$env:PATH`).
5. Set the PKG_CONFIG_PATH environment variable to `C:\dev\vcpkg\installed\x64-windows\lib\pkgconfig`.
6. Pull this branch.

Start by running this command from PowerShell:

```
./genshim.ps1
```

If pkgconf is found in your path, this should generate a new header file in Sources/CSDL2/windows_generated.h that contains this:

```
#include "C:/dev/vcpkg/installed/x64-windows/include/SDL2/SDL.h"
```

The next step is to build with `swift build`. After that, run the script `./copylibs.ps1` which will copy the necessary .lib and .dll files from where they were installed within /dev/vcpkg. Finally, run `swift test` and the unit tests should run correctly.

### Testing

I've tested the build results with some SDL test programs that I run on Mac and Linux.

### Checklist

- [ ] I've read the [Contribution Guidelines](https://github.com/ctreffs/SwiftSDL2/blob/master/CONTRIBUTING.md)
- [ ] I've followed the coding style of the rest of the project.
- [ ] I've added tests covering all new code paths my change adds to the project (to the extent possible).
- [ ] I've added benchmarks covering new functionality (if appropriate).
- [ ] I've verified that my change does not break any existing tests or introduce unexpected benchmark regressions.
- [ ] I've updated the documentation (if appropriate).
