### PR TITLE
Xcode Version 14.2 (14C18) build error

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -15,12 +15,12 @@ let package = Package(
     targets: [
         .target(name: "SDL",
                 dependencies: [
-                    .target(name: "SDL2-apple", condition: .when(platforms: [.macOS, .iOS, .tvOS])),
+                    .target(name: "SDL2", condition: .when(platforms: [.macOS, .iOS, .tvOS])),
                     .target(name: "CSDL2", condition: .when(platforms: [.linux, .windows])),
                 ],
                 path: "Sources/SDL2"),
         .testTarget(name: "SDLTests", dependencies: ["SDL"]),
-        .binaryTarget(name: "SDL2-apple", path: "SDL2.xcframework"),
+        .binaryTarget(name: "SDL2", path: "SDL2.xcframework"),
         .systemLibrary(
             name: "CSDL2",
             pkgConfig: "sdl2",


### PR DESCRIPTION
```bash
% xcode-select -p
/Applications/Xcode.app/Contents/Developer
% xcodebuild -version
Xcode 14.2
Build version 14C18
% swift build
error: local binary target 'SDL2-apple' does not contain expected binary artifact named 'SDL2-apple'
[0/1] Planning builderror: 'swiftsdl2': binary target 'SDL2-apple' could not be mapped to an artifact with expected name 'SDL2-apple'
```

Attached patch seems to fix build.