### PR TITLE
Fix xcframework target naming issues with Swift versions before 5.8

### DIFF
--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -65,3 +65,48 @@ jobs:
           path: |
             SDL2.xcframework.zip
             SDL2.xcframework.checksum.txt
+
+  macos-test-build-release-xcode-legacy:
+    runs-on: macos-12
+    strategy:
+      matrix:
+        xcode: ["13.4.1"]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3.5.3
+      
+      - name: Select Xcode ${{ matrix.xcode }}
+        run: sudo xcode-select -s /Applications/Xcode_${{ matrix.xcode }}.app
+
+      - name: Test
+        run: swift test
+        env:
+          DEVELOPER_DIR: /Applications/Xcode_${{ matrix.xcode }}.app/Contents/Developer
+
+      - name: Upload test artifacts
+        if: failure()
+        uses: actions/upload-artifact@v3.1.2
+        with:
+          name: test-artifacts-${{ matrix.xcode }}-${{ github.run_id }}
+          path: |
+            .build/**/*.json
+            .build/**/*.xctest
+
+      - name: Build Release
+        run: swift build -c release
+        env:
+          DEVELOPER_DIR: /Applications/Xcode_${{ matrix.xcode }}.app/Contents/Developer
+
+      - name: Upload build artifacts
+        if: failure()
+        uses: actions/upload-artifact@v3.1.2
+        with:
+          name: build-artifacts-${{ matrix.xcode }}-${{ github.run_id }}
+          path: |
+            *.lcov
+            .build/*.yaml
+            .build/**/*.a
+            .build/**/*.so
+            .build/**/*.dylib
+            .build/**/*.dSYM 
+            .build/**/*.json

--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: macos-13
     strategy:
       matrix:
-        xcode: ["14.3.1"]
+        xcode: ["14.1", "15.0"]
     steps:
       - name: Checkout
         uses: actions/checkout@v3.5.3

--- a/Package.swift
+++ b/Package.swift
@@ -15,12 +15,12 @@ let package = Package(
     targets: [
         .target(name: "SDL",
                 dependencies: [
-                    .target(name: "SDL2-apple", condition: .when(platforms: [.macOS, .iOS, .tvOS])),
+                    .target(name: "SDL2", condition: .when(platforms: [.macOS, .iOS, .tvOS])),
                     .target(name: "CSDL2", condition: .when(platforms: [.linux, .windows])),
                 ],
                 path: "Sources/SDL2"),
         .testTarget(name: "SDLTests", dependencies: ["SDL"]),
-        .binaryTarget(name: "SDL2-apple", path: "SDL2.xcframework"),
+        .binaryTarget(name: "SDL2", path: "SDL2.xcframework"),
         .systemLibrary(
             name: "CSDL2",
             pkgConfig: "sdl2",


### PR DESCRIPTION
### Description

- Fixes an issue for Swift tool versions before 5.8 that does not allow a different target name than the xcframework referenced in a binary target.
- extends GH actions to test with minimum and maximum supported Swift version.

### Checklist

- [x] I've read the [Contribution Guidelines](https://github.com/ctreffs/SwiftSDL2/blob/master/CONTRIBUTING.md)
- [x] I've followed the coding style of the rest of the project.
- [x] I've verified that my change does not break any existing tests or introduce unexpected benchmark regressions.
